### PR TITLE
Special values treated as message properties

### DIFF
--- a/src/fields/details.field.spec.ts
+++ b/src/fields/details.field.spec.ts
@@ -1,6 +1,6 @@
 import { textZLogFormatter, ZLogFormatter } from '../formats';
 import { ZLogLevel } from '../log-level';
-import { zlogMessage } from '../log-message';
+import { zlogDetails, zlogMessage } from '../log-message';
 
 describe('zlofDetails', () => {
 
@@ -11,31 +11,31 @@ describe('zlofDetails', () => {
   });
 
   it('formats message details', () => {
-    expect(format(zlogMessage(ZLogLevel.Error, 'Message', { some: 'value' })))
+    expect(format(zlogMessage(ZLogLevel.Error, 'Message', zlogDetails({ some: 'value' }))))
         .toBe('[ERROR] Message { some: "value" }');
   });
   it('formats object within message details', () => {
-    expect(format(zlogMessage(ZLogLevel.Error, 'Message', { some: { index: 2, value: 1 } })))
+    expect(format(zlogMessage(ZLogLevel.Error, 'Message', zlogDetails({ some: { index: 2, value: 1 } }))))
         .toBe('[ERROR] Message { some: { index: 2; value: 1 } }');
   });
   it('formats empty object within message details', () => {
-    expect(format(zlogMessage(ZLogLevel.Error, 'Message', { some: {} })))
+    expect(format(zlogMessage(ZLogLevel.Error, 'Message', zlogDetails({ some: {} }))))
         .toBe('[ERROR] Message { some: {} }');
   });
   it('formats array within message details', () => {
-    expect(format(zlogMessage(ZLogLevel.Error, 'Message', { some: [1, 2, 3] })))
+    expect(format(zlogMessage(ZLogLevel.Error, 'Message', zlogDetails({ some: [1, 2, 3] }))))
         .toBe('[ERROR] Message { some: [1, 2, 3] }');
   });
   it('formats empty array within message details', () => {
-    expect(format(zlogMessage(ZLogLevel.Error, 'Message', { some: [] })))
+    expect(format(zlogMessage(ZLogLevel.Error, 'Message', zlogDetails({ some: [] }))))
         .toBe('[ERROR] Message { some: [] }');
   });
   it('formats properties with symbol keys', () => {
-    expect(format(zlogMessage(ZLogLevel.Error, 'Message', { [Symbol.for('test')]: 99 })))
+    expect(format(zlogMessage(ZLogLevel.Error, 'Message', zlogDetails({ [Symbol.for('test')]: 99 }))))
         .toBe('[ERROR] Message { Symbol(test): 99 }');
   });
   it('does not format properties with `undefined` values', () => {
-    expect(format(zlogMessage(ZLogLevel.Error, 'Message', { 'skip it': undefined })))
+    expect(format(zlogMessage(ZLogLevel.Error, 'Message', zlogDetails({ 'skip it': undefined }))))
         .toBe('[ERROR] Message');
   });
 });

--- a/src/fields/extra.field.spec.ts
+++ b/src/fields/extra.field.spec.ts
@@ -11,7 +11,7 @@ describe('zlofExtra', () => {
   });
 
   it('formats message extra', () => {
-    expect(format(zlogMessage(ZLogLevel.Error, 'Message', ['more', { to: 'report' }])))
+    expect(format(zlogMessage(ZLogLevel.Error, 'Message', 'more', { to: 'report' })))
         .toBe('[ERROR] Message ("more", { to: "report" })');
   });
   it('formats `null` parameter', () => {
@@ -23,11 +23,11 @@ describe('zlofExtra', () => {
         .toBe('[ERROR] Message (undefined)');
   });
   it('formats array parameter', () => {
-    expect(format(zlogMessage(ZLogLevel.Error, 'Message', [[1, 'or', 2]])))
+    expect(format(zlogMessage(ZLogLevel.Error, 'Message', [1, 'or', 2])))
         .toBe('[ERROR] Message ([1, "or", 2])');
   });
   it('formats empty array parameter', () => {
-    expect(format(zlogMessage(ZLogLevel.Error, 'Message', [[]])))
+    expect(format(zlogMessage(ZLogLevel.Error, 'Message', [])))
         .toBe('[ERROR] Message ([])');
   });
 });

--- a/src/fields/timestamp.field.spec.ts
+++ b/src/fields/timestamp.field.spec.ts
@@ -1,6 +1,6 @@
 import { textZLogFormatter, ZLogFormatter } from '../formats';
 import { ZLogLevel } from '../log-level';
-import { zlogMessage } from '../log-message';
+import { zlogDetails, zlogMessage } from '../log-message';
 import { zlofTimestamp } from './timestamp.field';
 
 describe('zlofTimestamp', () => {
@@ -15,19 +15,28 @@ describe('zlofTimestamp', () => {
 
     const date = new Date();
 
-    expect(format(zlogMessage(ZLogLevel.Info, { timestamp: date }))).toBe(`${date.toISOString()} [INFO ]`);
+    expect(format(zlogMessage(
+        ZLogLevel.Info,
+        zlogDetails({ timestamp: date }),
+    ))).toBe(`${date.toISOString()} [INFO ]`);
   });
   it('recognizes `number` timestamp', () => {
 
     const date = new Date();
 
-    expect(format(zlogMessage(ZLogLevel.Info, { timestamp: date.getTime() }))).toBe(`${date.toISOString()} [INFO ]`);
+    expect(format(zlogMessage(
+        ZLogLevel.Info,
+        zlogDetails({ timestamp: date.getTime() }),
+    ))).toBe(`${date.toISOString()} [INFO ]`);
   });
   it('recognizes `string` timestamp', () => {
 
     const date = new Date().toUTCString();
 
-    expect(format(zlogMessage(ZLogLevel.Info, { timestamp: date }))).toBe(`${date} [INFO ]`);
+    expect(format(zlogMessage(
+        ZLogLevel.Info,
+        zlogDetails({ timestamp: date }),
+    ))).toBe(`${date} [INFO ]`);
   });
   it('does not write missing timestamp', () => {
     expect(format(zlogMessage(ZLogLevel.Info))).toBe(`[INFO ]`);
@@ -39,7 +48,10 @@ describe('zlofTimestamp', () => {
 
       const date = new Date();
 
-      expect(format(zlogMessage(ZLogLevel.Info, { timestamp: date }))).toBe(`${date.getTime()}`);
+      expect(format(zlogMessage(
+          ZLogLevel.Info,
+          zlogDetails({ timestamp: date }),
+      ))).toBe(`${date.getTime()}`);
     });
     it('accepts `Intl.DateTimeFormat` function', () => {
 
@@ -49,7 +61,10 @@ describe('zlofTimestamp', () => {
 
       const date = new Date();
 
-      expect(format(zlogMessage(ZLogLevel.Info, { timestamp: date }))).toBe(`${dtFormat.format(date)}`);
+      expect(format(zlogMessage(
+          ZLogLevel.Info,
+          zlogDetails({ timestamp: date }),
+      ))).toBe(`${dtFormat.format(date)}`);
     });
   });
 
@@ -59,7 +74,10 @@ describe('zlofTimestamp', () => {
 
       const date = new Date();
 
-      expect(format(zlogMessage(ZLogLevel.Info, { date }))).toBe(`${date.toISOString()}`);
+      expect(format(zlogMessage(
+          ZLogLevel.Info,
+          zlogDetails({ date }),
+      ))).toBe(`${date.toISOString()}`);
     });
   });
 });

--- a/src/log-message-data.impl.ts
+++ b/src/log-message-data.impl.ts
@@ -1,0 +1,43 @@
+import type { ZLogDetails } from './log-message';
+
+/**
+ * @internal
+ */
+export const ZLogMessageData__symbol = (/*#__PURE__*/ Symbol('zlog-message-data'));
+
+/**
+ * @internal
+ */
+export type ZLogMessageData =
+    | ZLogMessageData.Details
+    | ZLogMessageData.Error
+    | ZLogMessageData.Extra;
+
+/**
+ * @internal
+ */
+export namespace ZLogMessageData {
+
+  export interface Details {
+    readonly [ZLogMessageData__symbol]: 'details';
+    readonly details: ZLogDetails;
+  }
+
+  export interface Error {
+    readonly [ZLogMessageData__symbol]: 'error';
+    readonly error: any;
+  }
+
+  export interface Extra {
+    readonly [ZLogMessageData__symbol]: 'extra';
+    readonly extra: any[];
+  }
+
+}
+
+/**
+ * @internal
+ */
+export function isZLogMessageData(value: any): value is ZLogMessageData {
+  return !!value[ZLogMessageData__symbol];
+}

--- a/src/log-message.spec.ts
+++ b/src/log-message.spec.ts
@@ -1,5 +1,5 @@
 import { ZLogLevel } from './log-level';
-import { zlogMessage } from './log-message';
+import { zlogDetails, zlogError, zlogExtra, zlogMessage } from './log-message';
 
 describe('zlogMessage', () => {
   it('treats the first textual argument as message text', () => {
@@ -23,6 +23,19 @@ describe('zlogMessage', () => {
       extra: [1, 2, error2],
     });
   });
+  it('treats the first `zlogError()` result as error', () => {
+
+    const error1 = new Error('error1');
+    const error2 = new Error('error2');
+
+    expect(zlogMessage(ZLogLevel.Error, 1, 2, zlogError(error1), zlogError(error2))).toEqual({
+      level: ZLogLevel.Error,
+      text: error1.message,
+      error: error1,
+      details: {},
+      extra: [1, 2, error2],
+    });
+  });
   it('does not override message text with error message', () => {
 
     const error = new Error('error');
@@ -30,7 +43,19 @@ describe('zlogMessage', () => {
     expect(zlogMessage(ZLogLevel.Error, 1, 2, 'text', error)).toEqual({
       level: ZLogLevel.Error,
       text: 'text',
-      error: error,
+      error,
+      details: {},
+      extra: [1, 2],
+    });
+  });
+  it('does not set message text with non-error `zlogError()` result', () => {
+
+    const error = 'error';
+
+    expect(zlogMessage(ZLogLevel.Error, 1, 2, zlogError(error))).toEqual({
+      level: ZLogLevel.Error,
+      text: '',
+      error,
       details: {},
       extra: [1, 2],
     });
@@ -47,8 +72,13 @@ describe('zlogMessage', () => {
       extra: [1, 2],
     });
   });
-  it('treats objects as message details', () => {
-    expect(zlogMessage(ZLogLevel.Debug, { test: 'value' }, { test2: 'value2' }, 'msg')).toEqual({
+  it('treats `zlogDetails()` result as message details', () => {
+    expect(zlogMessage(
+        ZLogLevel.Debug,
+        zlogDetails({ test: 'value' }),
+        zlogDetails({ test2: 'value2' }),
+        'msg',
+    )).toEqual({
       level: ZLogLevel.Debug,
       text: 'msg',
       details: {
@@ -58,8 +88,8 @@ describe('zlogMessage', () => {
       extra: [],
     });
   });
-  it('treats arrays as message extra', () => {
-    expect(zlogMessage(ZLogLevel.Error, ['text', 2])).toEqual({
+  it('treats `zlogExtra()` result as message extra', () => {
+    expect(zlogMessage(ZLogLevel.Error, zlogExtra('text', 2))).toEqual({
       level: ZLogLevel.Error,
       text: '',
       details: {},

--- a/src/log-message.ts
+++ b/src/log-message.ts
@@ -3,6 +3,7 @@
  * @module @run-z/log-z
  */
 import type { ZLogLevel } from './log-level';
+import { isZLogMessageData, ZLogMessageData, ZLogMessageData__symbol } from './log-message-data.impl';
 
 /**
  * Log message.
@@ -33,7 +34,7 @@ export interface ZLogMessage {
    *
    * The keys of this map are specific to application or log recorder implementation.
    */
-  readonly details: Readonly<Record<string | symbol, any>>;
+  readonly details: ZLogDetails;
 
   /**
    * Extra uninterpreted parameters of this message passed to the logging method.
@@ -43,16 +44,25 @@ export interface ZLogMessage {
 }
 
 /**
+ * Log message details map.
+ *
+ * The keys of this map are specific to application or log recorder implementation.
+ */
+export type ZLogDetails = { readonly [key in string | symbol]?: any };
+
+/**
  * Builds a log message.
  *
  * Treats the first textual argument as {@link ZLogMessage.text message text}.
  *
- * Treats the first `Error` instance argument as {@link ZLogMessage.error message error}, and its message as
- * {@link ZLogMessage.text message text}, unless there is another textual argument.
+ * Treats the first special value created by {@link zlogError} function or the first `Error` instance as an error.
+ * Treats error message as a {@link ZLogMessage.text message text}, unless there is another textual argument.
  *
- * Treats the properties of object arguments as {@link ZLogMessage.details message details}.
+ * Treats special values created by {@link zlogDetails} function as additional {@link ZLogMessage.details message
+ * details}.
  *
- * Treats elements of array arguments as {@link ZLogMessage.extra message extra} entries.
+ * Treats special values created by {@link zlogExtra} function as additional {@link ZLogMessage.extra uninterpreted
+ * message parameters}.
  *
  * Treats the rest of arguments as {@link ZLogMessage.extra message extra}.
  *
@@ -66,8 +76,27 @@ export function zlogMessage(level: number, ...args: any[]): ZLogMessage {
   let text = '';
   let hasText = false;
   let error: any | undefined;
+  let hasError = false;
   const details: Record<string | symbol, any> = {};
   const extra = [];
+
+  const setError = (newError: any, newText?: string): void => {
+    if (hasError) {
+      extra.push(newError);
+      return;
+    }
+
+    hasError = true;
+    error = newError;
+
+    if (!hasText) {
+      if (newText !== undefined) {
+        text = newText;
+      } else if (newError instanceof Error) {
+        text = newError.message;
+      }
+    }
+  };
 
   for (const arg of args) {
     if (typeof arg === 'string') {
@@ -77,26 +106,22 @@ export function zlogMessage(level: number, ...args: any[]): ZLogMessage {
         continue;
       }
     } else if (arg && typeof arg === 'object') {
-      if (Array.isArray(arg)) {
-        extra.push(...arg);
-        continue;
-      }
-
-      if (arg instanceof Error) {
-        if (!error) {
-          error = arg;
-          if (!hasText) {
-            text = error.message;
-          }
+      if (isZLogMessageData(arg)) {
+        switch (arg[ZLogMessageData__symbol]) {
+        case 'error':
+          setError((arg as ZLogMessageData.Error).error);
+          continue;
+        case 'details':
+          Object.assign(details, (arg as ZLogMessageData.Details).details);
+          continue;
+        case 'extra':
+          extra.push(...(arg as ZLogMessageData.Extra).extra);
           continue;
         }
-        extra.push(arg);
+      } else if (arg instanceof Error) {
+        setError(arg, arg.message);
         continue;
       }
-
-      Object.assign(details, arg);
-
-      continue;
     }
 
     extra.push(arg);
@@ -107,6 +132,57 @@ export function zlogMessage(level: number, ...args: any[]): ZLogMessage {
     text,
     error,
     details,
+    extra,
+  };
+}
+
+/**
+ * Builds a special value {@link zlogMessage treated} as additional {@link ZLogMessage.details message details}.
+ *
+ * The resulting value can be passed to {@link zlogMessage} function or to {@link ZLogger.log logger method} to add
+ * details to logged message.
+ *
+ * @param details  Log message details to add.
+ *
+ * @returns A special value.
+ */
+export function zlogDetails(details: ZLogDetails): unknown {
+  return {
+    [ZLogMessageData__symbol]: 'details',
+    details,
+  };
+}
+
+/**
+ * Builds a special value {@link zlogMessage treated} as {@link ZLogMessage.error logged error}.
+ *
+ * The resulting value can be passed to {@link zlogMessage} function or to {@link ZLogger.log logger method} to set an
+ * error of logged message.
+ *
+ * @param error  Error to report.
+ *
+ * @returns A special value.
+ */
+export function zlogError(error: any): unknown {
+  return {
+    [ZLogMessageData__symbol]: 'error',
+    error,
+  };
+}
+
+/**
+ * Builds a special value {@link zlogMessage treated} as a list of {@link ZLogMessage.extra uninterpreted parameters}.
+ *
+ * The resulting value can be passed to {@link zlogMessage} function or to {@link ZLogger.log logger method} to add
+ * parameters of any type to logged message.
+ *
+ * @param extra  Log message parameters.
+ *
+ * @returns A special value.
+ */
+export function zlogExtra(...extra: any[]): unknown {
+  return {
+    [ZLogMessageData__symbol]: 'extra',
     extra,
   };
 }

--- a/src/logs/timestamp.log.spec.ts
+++ b/src/logs/timestamp.log.spec.ts
@@ -1,6 +1,6 @@
 import { logZ } from '../log';
 import { ZLogLevel } from '../log-level';
-import { zlogMessage } from '../log-message';
+import { zlogDetails, zlogMessage } from '../log-message';
 import type { ZLogRecorder } from '../log-recorder';
 import type { ZLogger } from '../logger';
 import { logZTimestamp } from './timestamp.log';
@@ -28,15 +28,15 @@ describe('logZTimestamp', () => {
     expect(target.record).toHaveBeenCalledWith(zlogMessage(
         ZLogLevel.Error,
         'Message',
-        { timestamp: expect.anything() },
+        zlogDetails({ timestamp: expect.anything() }),
     ));
   });
   it('does not override existing timestamp', () => {
-    logger.log(ZLogLevel.Error, 'Message', { timestamp: 'set' });
+    logger.log(ZLogLevel.Error, 'Message', zlogDetails({ timestamp: 'set' }));
     expect(target.record).toHaveBeenCalledWith(zlogMessage(
         ZLogLevel.Error,
         'Message',
-        { timestamp: 'set' },
+        zlogDetails({ timestamp: 'set' }),
     ));
   });
   it('records timestamp to custom details property', () => {
@@ -46,7 +46,7 @@ describe('logZTimestamp', () => {
     expect(target.record).toHaveBeenCalledWith(zlogMessage(
         ZLogLevel.Error,
         'Message',
-        { ts: expect.anything() },
+        zlogDetails({ ts: expect.anything() }),
     ));
   });
   it('generates timestamp by custom method', () => {
@@ -61,11 +61,11 @@ describe('logZTimestamp', () => {
       ),
     });
 
-    logger.log(ZLogLevel.Error, 'Message', { timestamp: 12 });
+    logger.log(ZLogLevel.Error, 'Message', zlogDetails({ timestamp: 12 }));
     expect(target.record).toHaveBeenCalledWith(zlogMessage(
         ZLogLevel.Error,
         'Message',
-        { timestamp: 12, ts: 13 },
+        zlogDetails({ timestamp: 12, ts: 13 }),
     ));
   });
 });

--- a/src/logs/to-console.log.spec.ts
+++ b/src/logs/to-console.log.spec.ts
@@ -1,5 +1,6 @@
 import { logZ } from '../log';
 import { ZLogLevel } from '../log-level';
+import { zlogDetails } from '../log-message';
 import type { ZLogger } from '../logger';
 import { logZToConsole } from './to-console.log';
 
@@ -68,7 +69,7 @@ describe('logZToConsole', () => {
     const error = new Error('!!!');
     const details = { details: 'many' };
 
-    logger.error(error, details, 'Error', [['extra']]);
+    logger.error(error, zlogDetails(details), 'Error', ['extra']);
     expect(errorSpy).toHaveBeenCalledWith('Error', ['extra'], details, error);
   });
 
@@ -133,7 +134,7 @@ describe('logZToConsole', () => {
       expect(debugSpy).toHaveBeenCalledWith('Error');
     });
     it('logs with `console.trace` with `stackTrace` set', () => {
-      logger.trace('Error', { stackTrace: true });
+      logger.trace('Error', zlogDetails({ stackTrace: true }));
       expect(traceSpy).toHaveBeenCalledWith('Error');
     });
     it('logs with `console.debug` with higher level', () => {

--- a/src/logs/updated.log.spec.ts
+++ b/src/logs/updated.log.spec.ts
@@ -1,7 +1,7 @@
 import { logZ } from '../log';
 import { ZLogLevel } from '../log-level';
 import type { ZLogMessage } from '../log-message';
-import { zlogMessage } from '../log-message';
+import { zlogDetails, zlogMessage } from '../log-message';
 import type { ZLogRecorder } from '../log-recorder';
 import type { ZLogger } from '../logger';
 import { logZUpdated } from './updated.log';
@@ -30,7 +30,7 @@ describe('logZUpdated', () => {
     update.mockImplementation(message => ({ ...message, details: { ...message.details, update: true } }));
 
     logger.error('Message');
-    expect(target.record).toHaveBeenCalledWith(zlogMessage(ZLogLevel.Error, 'Message', { update: true }));
+    expect(target.record).toHaveBeenCalledWith(zlogMessage(ZLogLevel.Error, 'Message', zlogDetails({ update: true })));
   });
 
   describe('whenLogged', () => {


### PR DESCRIPTION
Such values could be created by dedicated functions:

- `zlogDetails()`
- `zlogError()`
- `zlogExtra()`
