### PR TITLE
Loggable values

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,25 @@ or `zlogERROR`.
 [zlogMessage]: https://run-z.github.io/log-z/modules/@run-z_log-z.html#zlogMessage
 
 
+Loggable Values
+---------------
+
+A message error or any uninterpreted message parameter may be a loggable value. For that, it should implement
+a `toLog()` method that returns a loggable representation of the value. Such representation will be written to the log
+instead of original value. This can be used to log values in a special format.
+
+One possible usage scenario is deferring the actual evaluation of the logged message until it is written to the log.
+This can be done with [zlogDefer] function:
+```typescript
+logger.debug('Debug info', zlogDefer(() => zlogDetails({ info: evaluateDebugInfo() })));
+// `evaluateDebugInfo()` will be called only if `DEBUG` log level enabled.
+// Note that this will happen right before writing to the log,
+// which may happen at a later time, or not happen at all.
+``` 
+
+[zlogDefer]: https://run-z.github.io/log-z/modules/@run-z_log-z.html#zlogDefer
+
+
 Log Formats
 -----------
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ export * from './log-by';
 export * from './log-level';
 export * from './log-message';
 export * from './log-recorder';
+export * from './loggable';
 export * from './logger';
 export * from './logs';

--- a/src/log-message-builder.impl.ts
+++ b/src/log-message-builder.impl.ts
@@ -1,0 +1,101 @@
+import type { ZLogLevel } from './log-level';
+import type { ZLogMessage } from './log-message';
+import { isZLogMessageData, ZLogMessageData, ZLogMessageData__symbol } from './log-message-data.impl';
+
+/**
+ * @internal
+ */
+export class ZLogMessageBuilder {
+
+  protected text = '';
+  protected hasText = false;
+  protected error: any | undefined;
+  protected hasError = false;
+  protected details: Record<string | symbol, any> = {};
+  protected readonly extra: any[] = [];
+
+  constructor(private readonly level: ZLogLevel) {
+  }
+
+  setError(newError: any, newText?: string): void {
+    if (this.hasError) {
+      this.extra.push(newError);
+      return;
+    }
+
+    this.hasError = true;
+    this.error = newError;
+
+    if (!this.hasText) {
+      if (newText !== undefined) {
+        this.text = newText;
+      } else if (newError instanceof Error) {
+        this.text = newError.message;
+      }
+    }
+  }
+
+  addAll(args: readonly any[]): void {
+    args.forEach(arg => this.add(arg));
+  }
+
+  add(param: any): void {
+    if (typeof param === 'string') {
+      if (!this.hasText) {
+        this.text = param;
+        this.hasText = true;
+      } else if (param !== this.text) {
+        this.extra.push(param);
+      }
+      return;
+    }
+
+    if (param && typeof param === 'object') {
+      if (isZLogMessageData(param)) {
+        switch (param[ZLogMessageData__symbol]) {
+        case 'error':
+          this.setError((param as ZLogMessageData.Error).error);
+          return;
+        case 'details':
+          Object.assign(this.details, (param as ZLogMessageData.Details).details);
+          return;
+        case 'extra':
+          this.addExtra((param as ZLogMessageData.Extra).extra);
+          return;
+        }
+      }
+    }
+
+    if (this.addOther(param)) {
+      return;
+    }
+
+    if (param instanceof Error) {
+      this.setError(param, param.message);
+      return;
+    }
+
+    this.extra.push(param);
+  }
+
+  protected addExtra(extra: any[]): void {
+    this.extra.push(...extra);
+  }
+
+  protected addOther(_param: any): boolean {
+    return false;
+  }
+
+  message(): ZLogMessage {
+    return {
+      level: this.level,
+      text: this.text,
+      error: this.error,
+      details: this.details,
+      extra: this.extra,
+    };
+  }
+
+}
+
+

--- a/src/log.ts
+++ b/src/log.ts
@@ -16,6 +16,8 @@ export interface ZLogSpec {
   /**
    * The minimum log level of logged messages. The messages with lower levels will be discarded.
    *
+   * Zero or negative value means to log everything.
+   *
    * @default {@link ZLogLevel.Info Info}.
    */
   readonly atLeast?: ZLogLevel;

--- a/src/loggable.spec.ts
+++ b/src/loggable.spec.ts
@@ -1,5 +1,5 @@
 import { zlogINFO } from './levels';
-import { zlogDetails, zlogExtra } from './log-message';
+import { zlogDetails, zlogError, zlogExtra } from './log-message';
 import { zlogDefer, zlogExpand } from './loggable';
 
 describe('zlogExpand', () => {
@@ -38,5 +38,25 @@ describe('zlogExpand', () => {
   it('recursively expands deferred value', () => {
     expect(zlogExpand(zlogINFO('Message', 1, zlogDefer(() => zlogDefer(() => [2, 3])))))
         .toEqual(zlogINFO('Message', zlogExtra(1, 2, 3)));
+  });
+  it('preserves message error', () => {
+
+    const error = new Error('Test');
+
+    expect(zlogExpand(zlogINFO(error))).toEqual(zlogINFO(zlogError(error)));
+  });
+  it('expands message error', () => {
+
+    class TestError extends Error {
+
+      toLog(): unknown {
+        return zlogDetails({ error: this.message + '!' });
+      }
+
+    }
+
+    const error = new TestError('Test');
+
+    expect(zlogExpand(zlogINFO('Message', error))).toEqual(zlogINFO('Message', zlogDetails({ error: 'Test!' })));
   });
 });

--- a/src/loggable.spec.ts
+++ b/src/loggable.spec.ts
@@ -1,0 +1,42 @@
+import { zlogINFO } from './levels';
+import { zlogDetails, zlogExtra } from './log-message';
+import { zlogDefer, zlogExpand } from './loggable';
+
+describe('zlogExpand', () => {
+  it('expands message text', () => {
+    expect(zlogExpand(zlogINFO(zlogDefer(() => 'Message'))))
+        .toEqual(zlogINFO('Message'));
+  });
+  it('expands string to message extra if message is present already', () => {
+    expect(zlogExpand(zlogINFO('Message', zlogDefer(() => 'Extra'))))
+        .toEqual(zlogINFO('Message', zlogExtra('Extra')));
+  });
+  it('ignores expanded string equal to message text', () => {
+    expect(zlogExpand(zlogINFO('Message', zlogDefer(() => 'Message'))))
+        .toEqual(zlogINFO('Message'));
+  });
+  it('ignores expanded `null`', () => {
+    expect(zlogExpand(zlogINFO('Message', zlogDefer(() => null))))
+        .toEqual(zlogINFO('Message'));
+  });
+  it('expands message details', () => {
+    expect(zlogExpand(zlogINFO('Message', zlogDetails({ test1: 1 }), zlogDefer(() => zlogDetails({ test2: 2 })))))
+        .toEqual(zlogINFO('Message', zlogDetails({ test1: 1, test2: 2 })));
+  });
+  it('expands message extra', () => {
+    expect(zlogExpand(zlogINFO('Message', 1, zlogDefer(() => 2))))
+        .toEqual(zlogINFO('Message', zlogExtra(1, 2)));
+  });
+  it('expands message extra array', () => {
+    expect(zlogExpand(zlogINFO('Message', 1, zlogDefer(() => [2, 3]))))
+        .toEqual(zlogINFO('Message', zlogExtra(1, 2, 3)));
+  });
+  it('recursively expands loggable', () => {
+    expect(zlogExpand(zlogINFO('Message', 1, zlogDefer(() => ({ toLog: () => [2, 3] })))))
+        .toEqual(zlogINFO('Message', zlogExtra(1, 2, 3)));
+  });
+  it('recursively expands deferred value', () => {
+    expect(zlogExpand(zlogINFO('Message', 1, zlogDefer(() => zlogDefer(() => [2, 3])))))
+        .toEqual(zlogINFO('Message', zlogExtra(1, 2, 3)));
+  });
+});

--- a/src/loggable.ts
+++ b/src/loggable.ts
@@ -1,0 +1,124 @@
+/**
+ * @packageDocumentation
+ * @module @run-z/log-z
+ */
+import type { ZLogMessage } from './log-message';
+import { zlogExtra } from './log-message';
+import { ZLogMessageBuilder } from './log-message-builder.impl';
+
+/**
+ * Arbitrary loggable value.
+ */
+export interface ZLoggable {
+
+  /**
+   * Constructs a representation of this value suitable for logging.
+   *
+   * The log representation can be anything. It is up to the logger implementation to interpret it.
+   * The {@link zlogExpand} function is used by default to expand loggable objects.
+   *
+   * @returns Loggable value representation.
+   */
+  toLog(): any;
+
+}
+
+/**
+ * Builds a special value {@link zlogMessage treated} as {@link ZLoggable loggable} parameter.
+ *
+ * The resulting value can be passed to {@link zlogMessage} function or to {@link ZLogger.log logger method} to add
+ * it to logged message. It will be {@link zlogExpand expanded} only when the message is actually logged.
+ *
+ * @param toLog  Builds a loggable value representation.
+ */
+export function zlogDefer(toLog: () => any): unknown {
+  return zlogExtra({ toLog });
+}
+
+/**
+ * @internal
+ */
+class ZLogMessageExpander extends ZLogMessageBuilder {
+
+  constructor(message: ZLogMessage) {
+    super(message.level);
+    this.text = message.text;
+    this.hasText = !!this.text;
+    this.error = message.error;
+    this.hasError = !!this.error;
+    this.details = { ...message.details };
+  }
+
+  add(param: any): void {
+    if (isLoggable(param)) {
+      this.addLoggable(param);
+    } else {
+      this.extra.push(param);
+    }
+  }
+
+  private addLoggable(loggable: ZLoggable): void {
+
+    const value = loggable.toLog();
+
+    if (value != null) {
+      super.add(value);
+    }
+  }
+
+  protected addExtra(extra: any[]): void {
+    extra.forEach(e => this.add(e));
+  }
+
+  protected addOther(param: any): boolean {
+    if (isLoggable(param)) {
+      this.addLoggable(param);
+      return true;
+    }
+
+    if (Array.isArray(param)) {
+      param.forEach(p => super.add(p));
+      return true;
+    }
+
+    return false;
+  }
+
+}
+
+/**
+ * Expands log message by interpreting {@link ZLogMessage.extra uninterpreted parameters}.
+ *
+ * If parameter is a {@link ZLoggable loggable value}, then extracts its {@link ZLoggable.toLog loggable
+ * representation}, and processes as following:
+ *
+ * 1. ignores `null` and `undefined`,
+ * 2. ignores a string equal to the {@link ZLogMessage.text message text},
+ * 3. treats a special value created by one of {@link zlogDetails}, {@link zlogError}, or {@link zlogExtra} accordingly,
+ * 4. processed {@link ZLoggable loggable value} recursively,
+ * 5. treats a string as a {@link ZLogMessage.text message text}, unless the message has it already, in which case it
+ *    is treated as {@link ZLogMessage.extra uninterpreted parameter},
+ * 6. treats an `Error` instance as a {@link ZLogMessage.error message error}, unless the message has it already,
+ *    in which case it is treated as {@link ZLogMessage.extra uninterpreted parameter},
+ * 7. processes each array element recursively,
+ * 8. treats everything else as {@link ZLogMessage.extra uninterpreted parameter}.
+ *
+ * @param message  A message to expand.
+ *
+ * @returns Expanded log message.
+ */
+export function zlogExpand(message: ZLogMessage): ZLogMessage {
+
+  const expander = new ZLogMessageExpander(message);
+
+  expander.addAll(message.extra);
+
+  return expander.message();
+}
+
+/**
+ * @internal
+ */
+function isLoggable(value: any): value is ZLoggable {
+  return !!(value as Partial<ZLoggable>).toLog;
+}

--- a/src/loggable.ts
+++ b/src/loggable.ts
@@ -42,11 +42,20 @@ class ZLogMessageExpander extends ZLogMessageBuilder {
 
   constructor(message: ZLogMessage) {
     super(message.level);
-    this.text = message.text;
-    this.hasText = !!this.text;
-    this.error = message.error;
-    this.hasError = !!this.error;
+
+    const { text, error } = message;
+
+    this.text = text;
+    this.hasText = !!text;
+
     this.details = { ...message.details };
+
+    if (isLoggable(error)) {
+      this.add(error);
+    } else {
+      this.error = error;
+      this.hasError = error != null;
+    }
   }
 
   add(param: any): void {
@@ -87,9 +96,10 @@ class ZLogMessageExpander extends ZLogMessageBuilder {
 }
 
 /**
- * Expands log message by interpreting {@link ZLogMessage.extra uninterpreted parameters}.
+ * Expands a log message by replacing its {@link ZLogMessage.error error} and {@link ZLogMessage.extra uninterpreted
+ * parameters} with their loggable representations.
  *
- * If parameter is a {@link ZLoggable loggable value}, then extracts its {@link ZLoggable.toLog loggable
+ * If error or parameter is a {@link ZLoggable loggable value}, then extracts its {@link ZLoggable.toLog loggable
  * representation}, and processes as following:
  *
  * 1. ignores `null` and `undefined`,
@@ -120,5 +130,5 @@ export function zlogExpand(message: ZLogMessage): ZLogMessage {
  * @internal
  */
 function isLoggable(value: any): value is ZLoggable {
-  return !!(value as Partial<ZLoggable>).toLog;
+  return !!value && typeof value === 'object' && typeof value.toLog === 'function';
 }

--- a/src/logs/to-console.log.spec.ts
+++ b/src/logs/to-console.log.spec.ts
@@ -1,6 +1,7 @@
 import { logZ } from '../log';
 import { ZLogLevel } from '../log-level';
 import { zlogDetails, zlogExtra } from '../log-message';
+import { zlogDefer } from '../loggable';
 import type { ZLogger } from '../logger';
 import { logZToConsole } from './to-console.log';
 
@@ -82,6 +83,11 @@ describe('logZToConsole', () => {
   it('logs extra without message text', () => {
     logger.error(zlogExtra('extra', 1, 2));
     expect(errorSpy).toHaveBeenCalledWith('extra', 1, 2);
+  });
+
+  it('expands the message', () => {
+    logger.error(zlogDefer(() => 'Expanded'));
+    expect(errorSpy).toHaveBeenCalledWith('Expanded');
   });
 
   describe('fatal', () => {

--- a/src/logs/to-console.log.spec.ts
+++ b/src/logs/to-console.log.spec.ts
@@ -1,6 +1,6 @@
 import { logZ } from '../log';
 import { ZLogLevel } from '../log-level';
-import { zlogDetails } from '../log-message';
+import { zlogDetails, zlogExtra } from '../log-message';
 import type { ZLogger } from '../logger';
 import { logZToConsole } from './to-console.log';
 
@@ -55,16 +55,23 @@ describe('logZToConsole', () => {
     expect(errorSpy).toHaveBeenCalledWith(error.message, error);
   });
 
-  it('logs details', () => {
+  it('logs details before error', () => {
 
     const error = new Error('!!!');
     const details = { details: 'many' };
 
-    logger.error(error, details);
+    logger.error(error, zlogDetails(details));
     expect(errorSpy).toHaveBeenCalledWith(error.message, details, error);
   });
+  it('logs details without message text', () => {
 
-  it('logs extra', () => {
+    const details = { details: 'many' };
+
+    logger.error(zlogDetails(details));
+    expect(errorSpy).toHaveBeenCalledWith(details);
+  });
+
+  it('logs extra before details and error', () => {
 
     const error = new Error('!!!');
     const details = { details: 'many' };
@@ -72,11 +79,19 @@ describe('logZToConsole', () => {
     logger.error(error, zlogDetails(details), 'Error', ['extra']);
     expect(errorSpy).toHaveBeenCalledWith('Error', ['extra'], details, error);
   });
+  it('logs extra without message text', () => {
+    logger.error(zlogExtra('extra', 1, 2));
+    expect(errorSpy).toHaveBeenCalledWith('extra', 1, 2);
+  });
 
   describe('fatal', () => {
     it('logs with `console.error` and FATAL! prefix', () => {
       logger.fatal('Error');
       expect(errorSpy).toHaveBeenCalledWith('FATAL! Error');
+    });
+    it('logs FATAL! prefix only without message text', () => {
+      logger.fatal(zlogDetails({ fatal: true }));
+      expect(errorSpy).toHaveBeenCalledWith('FATAL!', { fatal: true });
     });
     it('logs with `console.error` and FATAL! prefix with higher level', () => {
       logger.log(ZLogLevel.Fatal + 1, 'Error');

--- a/src/logs/to-console.log.ts
+++ b/src/logs/to-console.log.ts
@@ -18,7 +18,7 @@ type ConsoleZLogMethod = (this: void, console: Console, message: ZLogMessage) =>
  */
 const consoleZLogMethods: [ConsoleZLogMethod, ...ConsoleZLogMethod[]] = [
   // Below TRACE
-  (console, message) => console.debug(message.text, ...consoleZLogArgs(message)),
+  (console, message) => console.debug(...consoleZLogArgs(message)),
   // TRACE
   (console, message) => {
 
@@ -27,24 +27,24 @@ const consoleZLogMethods: [ConsoleZLogMethod, ...ConsoleZLogMethod[]] = [
 
     delete debugDetails.stackTrace;
 
-    const args = consoleZLogArgs(message, debugDetails);
+    const args = consoleZLogArgs(message, '', debugDetails);
 
     if (details.stackTrace) {
-      console.trace(message.text, ...args);
+      console.trace(...args);
     } else {
-      console.debug(message.text, ...args);
+      console.debug(...args);
     }
   },
   // DEBUG
-  (console, message) => console.log(message.text, ...consoleZLogArgs(message)),
+  (console, message) => console.log(...consoleZLogArgs(message)),
   // INFO
-  (console, message) => console.info(message.text, ...consoleZLogArgs(message)),
+  (console, message) => console.info(...consoleZLogArgs(message)),
   // WARN
-  (console, message) => console.warn(message.text, ...consoleZLogArgs(message)),
+  (console, message) => console.warn(...consoleZLogArgs(message)),
   // ERROR
-  (console, message) => console.error(message.text, ...consoleZLogArgs(message)),
+  (console, message) => console.error(...consoleZLogArgs(message)),
   // FATAL
-  (console, message) => console.error(`FATAL! ${message.text}`, ...consoleZLogArgs(message)),
+  (console, message) => console.error(...consoleZLogArgs(message, 'FATAL!')),
 ];
 
 /**
@@ -92,15 +92,32 @@ function globalConsole(): typeof console {
 /**
  * @internal
  */
-function consoleZLogArgs(message: ZLogMessage, details = message.details): string[] {
+function consoleZLogArgs(
+    message: ZLogMessage,
+    prefix = '',
+    details = message.details,
+): string[] {
 
-  const args: any[] = [...message.extra];
+  const { text, error } = message;
+  const args: any[] = [];
+
+  if (prefix) {
+    if (text) {
+      args.push(`${prefix} ${text}`);
+    } else {
+      args.push(prefix);
+    }
+  } else if (text) {
+    args.push(text);
+  }
+
+  args.push(...message.extra);
 
   if (Object.getOwnPropertyNames(details).length || Object.getOwnPropertySymbols(details).length) {
     args.push(details);
   }
-  if (message.error) {
-    args.push(message.error);
+  if (error) {
+    args.push(error);
   }
 
   return args;

--- a/src/logs/to-console.log.ts
+++ b/src/logs/to-console.log.ts
@@ -7,6 +7,7 @@ import { zlogLevelMap } from '../log-level';
 import type { ZLogMessage } from '../log-message';
 import type { ZLogRecorder } from '../log-recorder';
 import { alreadyEnded, alreadyLogged, notLogged } from '../log-recorder.impl';
+import { zlogExpand } from '../loggable';
 
 /**
  * @internal
@@ -56,7 +57,10 @@ const consoleZLogMethods: [ConsoleZLogMethod, ...ConsoleZLogMethod[]] = [
  */
 export function logZToConsole(console = globalConsole()): ZLogRecorder {
 
-  let record = (message: ZLogMessage): void => zlogLevelMap(message.level, consoleZLogMethods)(console, message);
+  let record = (message: ZLogMessage): void => zlogLevelMap(message.level, consoleZLogMethods)(
+      console,
+      zlogExpand(message),
+  );
   let whenLogged = alreadyLogged;
   let end = (): Promise<void> => {
     record = noop;

--- a/src/logs/when-level.log.ts
+++ b/src/logs/when-level.log.ts
@@ -13,7 +13,7 @@ import { neverLogZ } from './never.log';
  * by another recorder, or discarded.
  *
  * @param when  Either required log level, or arbitrary condition implemented by function accepting log level and
- * returning `true` for satisfying level.
+ * returning `true` for satisfying level. Zero or negative value means to log everything.
  * @param by  The recorder to log messages satisfying log level condition.
  * @param orBy  The recorder to log messages not satisfying log level condition. Such messages will be discarded when
  * omitted.
@@ -48,6 +48,9 @@ export function logZWhenLevel(
   let when: ((this: void, level: ZLogLevel) => boolean);
 
   if (typeof whenOrBy === 'number') {
+    if (whenOrBy <= 0 && orBy === neverLogZ) {
+      return by;
+    }
     recorder = by;
     when = level => level >= whenOrBy;
   } else if (typeof whenOrBy === 'function') {

--- a/src/node/to-stream.log.spec.ts
+++ b/src/node/to-stream.log.spec.ts
@@ -3,7 +3,8 @@ import { levelZLogField, messageZLogField } from '../fields';
 import { textZLogFormatter } from '../formats';
 import { logZBy } from '../log-by';
 import { ZLogLevel } from '../log-level';
-import { zlogMessage } from '../log-message';
+import { zlogDetails, zlogMessage } from '../log-message';
+import { zlogDefer } from '../loggable';
 import { TestWritable } from '../spec';
 import { logZToStream } from './to-stream.log';
 
@@ -20,6 +21,21 @@ describe('logZToStream', () => {
     expect(await logger.whenLogged()).toBe(true);
 
     expect(out.chunks).toEqual([`[INFO ] TEST${os.EOL}`, `[ERROR] ERROR${os.EOL}`]);
+  });
+  it('expands message', async () => {
+
+    const out = new TestWritable();
+    const logger = logZBy(logZToStream(out));
+
+    logger.info(zlogDefer(() => ['TEST', zlogDetails({ expanded: true })]));
+    logger.error('ERROR');
+
+    expect(await logger.whenLogged()).toBe(true);
+
+    expect(out.chunks).toEqual([
+        `[INFO ] TEST { expanded: true }${os.EOL}`,
+        `[ERROR] ERROR${os.EOL}`,
+    ]);
   });
   it('formats message with custom format', async () => {
 

--- a/src/node/to-stream.log.ts
+++ b/src/node/to-stream.log.ts
@@ -10,6 +10,7 @@ import { textZLogFormatter } from '../formats';
 import type { ZLogMessage } from '../log-message';
 import type { ZLogRecorder } from '../log-recorder';
 import { alreadyLogged, notLogged } from '../log-recorder.impl';
+import { zlogExpand } from '../loggable';
 import type { WhenWritten } from './stream-writer.impl';
 import { streamWriter } from './stream-writer.impl';
 
@@ -123,7 +124,7 @@ function logRecorderFor(
   } else {
     record = message => {
 
-      const line = formatter(message);
+      const line = formatter(zlogExpand(message));
 
       return line == null ? notLogged : write(line + eol);
     };


### PR DESCRIPTION
- Introduce `ZLoggable` interface.
- Expand logged messages before writing to the log.
- `logZToConsole()`: Do not log empty message text.
- `logZWhenLevel()` with zero or negative level means "log everything".
