### PR TITLE
Nested message details formatting

### DIFF
--- a/src/fields/detail.field.spec.ts
+++ b/src/fields/detail.field.spec.ts
@@ -90,6 +90,19 @@ describe('detailZLogField', () => {
       expect(format(zlogERROR(zlogDetails({ some: { path: 2, value: 1 } }))))
           .toBe('2 { some: { value: 1 } }');
     });
+    it('extracts the only nested detail', () => {
+
+      const format = textZLogFormatter({
+        fields: [
+          detailZLogField('some', 'path'),
+          ' ',
+          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField()),
+        ],
+      });
+
+      expect(format(zlogERROR(zlogDetails({ some: { path: 2 }, other: {} }))))
+          .toBe('2 { other: {} }');
+    });
     it('does not log missing nested detail', () => {
 
       const format = textZLogFormatter({

--- a/src/fields/detail.field.spec.ts
+++ b/src/fields/detail.field.spec.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from '@jest/globals';
+import { textZLogFormatter } from '../formats';
+import { zlogERROR } from '../levels';
+import { zlogDetails } from '../log-details';
+import { decoratorZLogField } from './decorator.field';
+import { detailZLogField } from './detail.field';
+import { detailsZLogField } from './details.field';
+
+describe('detailZLogField', () => {
+  describe('with empty path', () => {
+    it('extracts message details', () => {
+
+      const format = textZLogFormatter({
+        fields: [
+          detailZLogField(),
+          ' ',
+          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField()),
+        ],
+      });
+
+      expect(format(zlogERROR(zlogDetails({ some: 'value' }))))
+          .toBe('{ some: "value" }');
+    });
+    it('extracts empty message details', () => {
+
+      const format = textZLogFormatter({
+        fields: [
+          detailZLogField(),
+          ' ',
+          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField()),
+        ],
+      });
+
+      expect(format(zlogERROR()))
+          .toBe('{}');
+    });
+    it('applies custom format', () => {
+      const format = textZLogFormatter({
+        fields: [
+          detailZLogField((line, { first, second }: { first: string; second: string }) => {
+            line.write(`${first}-${second}`);
+          }),
+          ' ',
+          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField()),
+        ],
+      });
+
+      expect(format(zlogERROR(zlogDetails({ first: '<', second: '>' }))))
+          .toBe('<->');
+    });
+  });
+
+  describe('with path', () => {
+    it('extracts detail', () => {
+
+      const format = textZLogFormatter({
+        fields: [
+          detailZLogField('path'),
+          ' ',
+          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField()),
+        ],
+      });
+
+      expect(format(zlogERROR(zlogDetails({ path: 2, value: 1 }))))
+          .toBe('2 { value: 1 }');
+    });
+    it('does not log missing detail', () => {
+
+      const format = textZLogFormatter({
+        fields: [
+          detailZLogField('path'),
+          ' ',
+          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField()),
+        ],
+      });
+
+      expect(format(zlogERROR(zlogDetails({ other: 2, value: 1 }))))
+          .toBe('{ other: 2, value: 1 }');
+    });
+    it('extracts nested detail', () => {
+
+      const format = textZLogFormatter({
+        fields: [
+          detailZLogField('some', 'path'),
+          ' ',
+          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField()),
+        ],
+      });
+
+      expect(format(zlogERROR(zlogDetails({ some: { path: 2, value: 1 } }))))
+          .toBe('2 { some: { value: 1 } }');
+    });
+    it('does not log missing nested detail', () => {
+
+      const format = textZLogFormatter({
+        fields: [
+          detailZLogField('some', 'path'),
+          ' ',
+          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField()),
+        ],
+      });
+
+      expect(format(zlogERROR(zlogDetails({ some: { other: 2, value: 1 } }))))
+          .toBe('{ some: { other: 2, value: 1 } }');
+    });
+    it('does not log the detail nested inside `null`', () => {
+
+      const format = textZLogFormatter({
+        fields: [
+          detailZLogField('some', 'path'),
+          ' ',
+          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField()),
+        ],
+      });
+
+      expect(format(zlogERROR(zlogDetails({ some: null }))))
+          .toBe('{ some: null }');
+    });
+    it('does not log the detail nested inside non-object', () => {
+
+      const format = textZLogFormatter({
+        fields: [
+          detailZLogField('some', 'path'),
+          ' ',
+          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField()),
+        ],
+      });
+
+      expect(format(zlogERROR(zlogDetails({ some: 'some' }))))
+          .toBe('{ some: "some" }');
+    });
+    it('applies custom format', () => {
+      const format = textZLogFormatter({
+        fields: [
+          detailZLogField(
+              (line, { first, second }: { first: string; second: string }) => {
+                line.write(`${first}-${second}`);
+              },
+              'some',
+          ),
+          ' ',
+          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField()),
+        ],
+      });
+
+      expect(format(zlogERROR(zlogDetails({ some: { first: '<', second: '>' } }))))
+          .toBe('<->');
+    });
+  });
+});

--- a/src/fields/detail.field.spec.ts
+++ b/src/fields/detail.field.spec.ts
@@ -133,10 +133,10 @@ describe('detailZLogField', () => {
       const format = textZLogFormatter({
         fields: [
           detailZLogField(
+              'some',
               (line, { first, second }: { first: string; second: string }) => {
                 line.write(`${first}-${second}`);
               },
-              'some',
           ),
           ' ',
           decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField()),

--- a/src/fields/detail.field.spec.ts
+++ b/src/fields/detail.field.spec.ts
@@ -14,7 +14,7 @@ describe('detailZLogField', () => {
         fields: [
           detailZLogField(),
           ' ',
-          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField()),
+          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField),
         ],
       });
 
@@ -27,7 +27,7 @@ describe('detailZLogField', () => {
         fields: [
           detailZLogField(),
           ' ',
-          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField()),
+          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField),
         ],
       });
 
@@ -41,7 +41,7 @@ describe('detailZLogField', () => {
             line.write(`${first}-${second}`);
           }),
           ' ',
-          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField()),
+          decoratorZLogField({ prefix: '{ ', suffix: ' }' }, detailsZLogField),
         ],
       });
 

--- a/src/fields/detail.field.ts
+++ b/src/fields/detail.field.ts
@@ -12,23 +12,36 @@ import type { ZLogDetails } from '../log-details';
  */
 export function detailZLogField(...path: (keyof ZLogDetails)[]): ZLogField;
 
-export function detailZLogField<T>(
-    write: (this: void, line: ZLogLine, value: T) => void,
-    ...path: (keyof ZLogDetails)[]
-): ZLogField;
+/**
+ * Creates a log field for {@link ZLogLine.extractDetail extracted} message detail in specific format.
+ *
+ * Writes the value with {@link ZLogLine.writeValue} method. Writes nothing if the target detail is undefined.
+ *
+ * @param pathAndWrite - A path to details property to extract and value writer function. Empty path means extracting
+ * of all details.
+ *
+ * @returns Log detail field.
+ */
+export function detailZLogField<T>(...pathAndWrite: [
+  ...path: (keyof ZLogDetails)[],
+  write: (this: void, line: ZLogLine, value: T) => void,
+]): ZLogField;
 
-export function detailZLogField<T>(
-    writeOrKey: ((this: void, line: ZLogLine, value: T) => void) | keyof ZLogDetails,
-    ...path: (keyof ZLogDetails)[]
-): ZLogField {
+export function detailZLogField<T>(...pathAndWrite: [
+  ...path: (keyof ZLogDetails)[],
+  ...write: [((this: void, line: ZLogLine, value: T) => void)?],
+]): ZLogField {
 
+  let path: (keyof ZLogDetails)[];
   let write: (this: void, line: ZLogLine, value: T) => void;
+  const writeOrKey = pathAndWrite[pathAndWrite.length - 1];
 
   if (typeof writeOrKey === 'function') {
+    path = pathAndWrite.slice(0, pathAndWrite.length - 1) as (keyof ZLogDetails)[];
     write = writeOrKey;
   } else {
+    path = pathAndWrite as (keyof ZLogDetails)[];
     write = detailZLogField$write;
-    path = writeOrKey != null ? [writeOrKey, ...path] : path;
   }
 
   return line => {

--- a/src/fields/detail.field.ts
+++ b/src/fields/detail.field.ts
@@ -1,0 +1,46 @@
+import type { ZLogField, ZLogLine } from '../formats';
+import type { ZLogDetails } from '../log-details';
+
+/**
+ * Creates a log field for {@link ZLogLine.extractDetail extracted} message detail.
+ *
+ * Writes the value with {@link ZLogLine.writeValue} method. Writes nothing if the target detail is undefined.
+ *
+ * @param path - A path to details property to extract. Empty path means extracting of all details.
+ *
+ * @returns Log detail field.
+ */
+export function detailZLogField(...path: (keyof ZLogDetails)[]): ZLogField;
+
+export function detailZLogField<T>(
+    write: (this: void, line: ZLogLine, value: T) => void,
+    ...path: (keyof ZLogDetails)[]
+): ZLogField;
+
+export function detailZLogField<T>(
+    writeOrKey: ((this: void, line: ZLogLine, value: T) => void) | keyof ZLogDetails,
+    ...path: (keyof ZLogDetails)[]
+): ZLogField {
+
+  let write: (this: void, line: ZLogLine, value: T) => void;
+
+  if (typeof writeOrKey === 'function') {
+    write = writeOrKey;
+  } else {
+    write = detailZLogField$write;
+    path = writeOrKey != null ? [writeOrKey, ...path] : path;
+  }
+
+  return line => {
+
+    const value = line.extractDetail(...path);
+
+    if (value !== undefined) {
+      write(line, value as T);
+    }
+  };
+}
+
+function detailZLogField$write(line: ZLogLine, value: unknown): void {
+  line.writeValue(value);
+}

--- a/src/fields/details.field.spec.ts
+++ b/src/fields/details.field.spec.ts
@@ -4,7 +4,7 @@ import { zlogDetails } from '../log-details';
 import { ZLogLevel } from '../log-level';
 import { zlogMessage } from '../log-message';
 
-describe('derailsZLogField', () => {
+describe('detailsZLogField', () => {
 
   let format: ZLogFormatter;
 
@@ -18,7 +18,7 @@ describe('derailsZLogField', () => {
   });
   it('formats object within message details', () => {
     expect(format(zlogMessage(ZLogLevel.Error, 'Message', zlogDetails({ some: { index: 2, value: 1 } }))))
-        .toBe('[ERROR] Message { some: { index: 2; value: 1 } }');
+        .toBe('[ERROR] Message { some: { index: 2, value: 1 } }');
   });
   it('formats empty object within message details', () => {
     expect(format(zlogMessage(ZLogLevel.Error, 'Message', zlogDetails({ some: {} }))))

--- a/src/fields/details.field.ts
+++ b/src/fields/details.field.ts
@@ -13,9 +13,9 @@ export function detailsZLogField(): ZLogField;
 export function detailsZLogField(line: ZLogLine): void;
 
 export function detailsZLogField(line?: ZLogLine): ZLogField | void {
-  if (line) {
-    line.writeProperties(line.message.details);
-  } else {
+  if (!line) {
     return detailsZLogField;
   }
+
+  line.writeProperties(line.message.details);
 }

--- a/src/fields/details.field.ts
+++ b/src/fields/details.field.ts
@@ -1,14 +1,21 @@
 import type { ZLogField, ZLogLine } from '../formats';
 
 /**
- * Creates a log field for {@link ZLogMessage.details message details}.
- *
- * @returns Log details field.
+ * A field for {@link ZLogMessage.details message details}.
  */
-export function detailsZLogField(): ZLogField {
-  return detailsZLogField$write;
-}
+export function detailsZLogField(): ZLogField;
 
-function detailsZLogField$write(line: ZLogLine): void {
-  line.writeProperties(line.message.details);
+/**
+ * Creates a field for {@link ZLogMessage.details message details}.
+ *
+ * @returns Itself for the convenience.
+ */
+export function detailsZLogField(line: ZLogLine): void;
+
+export function detailsZLogField(line?: ZLogLine): ZLogField | void {
+  if (line) {
+    line.writeProperties(line.message.details);
+  } else {
+    return detailsZLogField;
+  }
 }

--- a/src/fields/details.field.ts
+++ b/src/fields/details.field.ts
@@ -3,15 +3,12 @@ import type { ZLogField, ZLogLine } from '../formats';
 /**
  * Creates a log field for {@link ZLogMessage.details message details}.
  *
- * @returns Log extra field.
+ * @returns Log details field.
  */
 export function detailsZLogField(): ZLogField {
-  return formatZLogDetails;
+  return detailsZLogField$write;
 }
 
-/**
- * @internal
- */
-function formatZLogDetails(line: ZLogLine): void {
+function detailsZLogField$write(line: ZLogLine): void {
   line.writeProperties(line.message.details);
 }

--- a/src/fields/index.ts
+++ b/src/fields/index.ts
@@ -1,4 +1,5 @@
 export * from './decorator.field';
+export * from './detail.field';
 export * from './details.field';
 export * from './error.field';
 export * from './extra.field';

--- a/src/formats/log-line.ts
+++ b/src/formats/log-line.ts
@@ -1,3 +1,4 @@
+import type { ZLogDetails } from '../log-details';
 import type { ZLogMessage } from '../log-message';
 import type { ZLogField } from './log-field';
 
@@ -25,23 +26,64 @@ export abstract class ZLogLine {
   abstract changeMessage(newMessage: ZLogMessage): void;
 
   /**
+   * Extracts {@link ZLogMessage.details message details}, then {@link changeMessage changes} the message to format by
+   * excluding the extracted details from it.
+   *
+   * @returns Extracted message details.
+   */
+  extractDetail(): ZLogDetails;
+
+  /**
    * Extracts a property from {@link ZLogMessage.details message details}, then {@link changeMessage changes}
    * the message to format by excluding the extracted property from it.
    *
-   * @param key - A key of the property to extract.
+   * @param path - A path to details property to extract. Empty path means extracting of all details.
    *
-   * @returns Extracted property value.
+   * @returns Extracted message detail, or `undefined` if there is no such detail.
    */
-  extractDetail(key: string | symbol): unknown {
+  extractDetail(...path: (keyof ZLogDetails)[]): unknown;
 
-    const message = this.message;
-    const value = message.details[key as string]; // See BUG: https://github.com/microsoft/TypeScript/issues/1863
+  extractDetail(...path: (keyof ZLogDetails)[]): unknown {
 
-    if (value !== undefined) {
-      this.changeMessage({ ...message, details: { ...message.details, [key as string]: undefined } });
+    const { message } = this;
+    const last = path.length - 1;
+    let { details } = message;
+
+    if (last < 0) {
+      // Empty path - extracting all details.
+      this.changeMessage({ ...message, details: {} });
+
+      return details;
     }
 
-    return value;
+    let detailsReplacement!: Record<keyof ZLogDetails, unknown>;
+    let updatedDetails: Record<keyof ZLogDetails, unknown> = {};
+
+    for (let i = 0; ; ++i) {
+
+      const key = path[i] as string;
+      const value = details[key];
+
+      if (value === undefined) {
+        return;
+      }
+      if (!i) {
+        detailsReplacement = updatedDetails = { ...details };
+      }
+
+      if (i === last) {
+        delete updatedDetails[key];
+        this.changeMessage({ ...message, details: detailsReplacement });
+        return value;
+      }
+
+      if (value == null || typeof value !== 'object') {
+        return; // No such detail.
+      }
+
+      updatedDetails = updatedDetails[key] = { ...value };
+      details = value as ZLogDetails;
+    }
   }
 
   /**

--- a/src/formats/log-line.ts
+++ b/src/formats/log-line.ts
@@ -73,6 +73,7 @@ export abstract class ZLogLine {
 
       if (i === last) {
         delete updatedDetails[key];
+        ZLogLine$compactDetails(detailsReplacement, path, 0);
         this.changeMessage({ ...message, details: detailsReplacement });
         return value;
       }
@@ -251,4 +252,20 @@ export abstract class ZLogLine {
     this.write(String(value));
   }
 
+}
+
+function ZLogLine$compactDetails(
+    details: Record<keyof ZLogDetails, any>,
+    path: (keyof ZLogDetails)[],
+    index: number,
+): boolean {
+
+  const key = path[index] as string;
+  const nested = details[key];
+
+  if (nested && ZLogLine$compactDetails(nested, path, index + 1)) {
+    delete details[key];
+  }
+
+  return !Reflect.ownKeys(details).length;
 }

--- a/src/formats/log-line.ts
+++ b/src/formats/log-line.ts
@@ -149,7 +149,7 @@ export abstract class ZLogLine {
 
       if (formatted != null) {
         if (written) {
-          this.write('; ');
+          this.write(', ');
         } else {
           written = true;
         }


### PR DESCRIPTION
- Separate object properties with `,`
- `ZLogLine.extractDetail()` can extract nested message detail
- Add `detailZLogField()`
- Allow to use `detailsZLogField` as a text format field
